### PR TITLE
`AttributeAccess` extension methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use self::error::Error;
 /// Useful includes
 pub mod prelude {
     pub use crate::generate::{FnSelfArg, Generator};
-    pub use crate::parse::{Body, FromAttribute, Parse};
+    pub use crate::parse::{AttributeAccess, Body, FromAttribute, Parse};
     pub use crate::Result;
     pub use proc_macro2::*;
 }
@@ -91,7 +91,7 @@ pub mod prelude {
     extern crate proc_macro;
 
     pub use crate::generate::{FnSelfArg, Generator};
-    pub use crate::parse::{Body, FromAttribute, Parse};
+    pub use crate::parse::{AttributeAccess, Body, FromAttribute, Parse};
     pub use crate::Result;
     pub use proc_macro::*;
 }

--- a/src/parse/attributes.rs
+++ b/src/parse/attributes.rs
@@ -96,21 +96,14 @@ fn test_attributes_try_take() {
     }
 }
 
-/// Helper trait for functions like:
-/// - [`UnnamedField::has_attribute`]
-/// - [`UnnamedField::get_attribute`]
-/// - [`IdentOrIndex::has_attribute`]
-/// - [`IdentOrIndex::get_attribute`]
+/// Helper trait for [`AttributeAccess`] methods.
 ///
 /// This can be implemented on your own type to make parsing easier.
 ///
 /// Some functions that can make your life easier:
 /// - [`utils::parse_tagged_attribute`] is a helper for parsing attributes in the format of `#[prefix(...)]`
 ///
-/// [`IdentOrIndex::has_attribute`]: enum.IdentOrIndex.html#method.has_attribute
-/// [`IdentOrIndex::get_attribute`]: enum.IdentOrIndex.html#method.get_attribute
-/// [`UnnamedField::has_attribute`]: struct.UnnamedField.html#method.has_attribute
-/// [`UnnamedField::get_attribute`]: struct.UnnamedField.html#method.get_attribute
+/// [`AttributeAccess`]: trait.AttributeAccess.html
 /// [`utils::parse_tagged_attribute`]: ../utils/fn.parse_tagged_attribute.html
 pub trait FromAttribute: Sized {
     /// Try to parse the given group into your own type. Return `Ok(None)` if the parsing failed or if the attribute was not this type.

--- a/src/parse/attributes.rs
+++ b/src/parse/attributes.rs
@@ -116,3 +116,38 @@ pub trait FromAttribute: Sized {
     /// Try to parse the given group into your own type. Return `Ok(None)` if the parsing failed or if the attribute was not this type.
     fn parse(group: &Group) -> Result<Option<Self>>;
 }
+
+/// Bring useful methods to access attributes of an element.
+pub trait AttributeAccess {
+    /// Check to see if has the given attribute. See [`FromAttribute`] for more information.
+    ///
+    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
+    fn has_attribute<T: FromAttribute + PartialEq<T>>(&self, attrib: T) -> Result<bool>;
+
+    /// Returns the first attribute that returns `Some(Self)`. See [`FromAttribute`] for more information.
+    ///
+    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
+    fn get_attribute<T: FromAttribute>(&self) -> Result<Option<T>>;
+}
+
+impl AttributeAccess for Vec<Attribute> {
+    fn has_attribute<T: FromAttribute + PartialEq<T>>(&self, attrib: T) -> Result<bool> {
+        for attribute in self.iter() {
+            if let Some(attribute) = T::parse(&attribute.tokens)? {
+                if attribute == attrib {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    fn get_attribute<T: FromAttribute>(&self) -> Result<Option<T>> {
+        for attribute in self.iter() {
+            if let Some(attribute) = T::parse(&attribute.tokens)? {
+                return Ok(Some(attribute));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -1,5 +1,5 @@
 use super::attributes::AttributeLocation;
-use super::{utils::*, Attribute, FromAttribute, Visibility};
+use super::{utils::*, Attribute, Visibility};
 use crate::prelude::{Delimiter, Ident, Literal, Span, TokenTree};
 use crate::{Error, Result};
 use std::iter::Peekable;

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -527,6 +527,14 @@ impl<'a> IdentOrIndex<'a> {
             }
         }
     }
+
+    /// Returns the attributes of this field.
+    pub fn attributes(&self) -> &Vec<Attribute> {
+        match self {
+            Self::Ident { attributes, .. } => attributes,
+            Self::Index { attributes, .. } => attributes,
+        }
+    }
 }
 
 impl std::fmt::Display for IdentOrIndex<'_> {

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -467,32 +467,6 @@ impl UnnamedField {
             None => Span::call_site(),
         }
     }
-
-    /// Check to see if the field has the given attribute. See [`FromAttribute`] for more information.
-    ///
-    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
-    pub fn has_attribute<T: FromAttribute + PartialEq<T>>(&self, attrib: T) -> Result<bool> {
-        for attribute in self.attributes.iter() {
-            if let Some(attribute) = T::parse(&attribute.tokens)? {
-                if attribute == attrib {
-                    return Ok(true);
-                }
-            }
-        }
-        Ok(false)
-    }
-
-    /// Returns the first attribute that returns `Some(Self)`. See [`FromAttribute`] for more information.
-    ///
-    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
-    pub fn get_attribute<T: FromAttribute>(&self) -> Result<Option<T>> {
-        for attribute in self.attributes.iter() {
-            if let Some(attribute) = T::parse(&attribute.tokens)? {
-                return Ok(Some(attribute));
-            }
-        }
-        Ok(None)
-    }
 }
 
 /// Reference to an enum variant's field. Either by index or by ident.
@@ -552,40 +526,6 @@ impl<'a> IdentOrIndex<'a> {
                 format!("{}{}", prefix, index)
             }
         }
-    }
-
-    /// Check to see if the field has the given attribute. See [`FromAttribute`] for more information.
-    ///
-    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
-    pub fn has_attribute<T: FromAttribute + PartialEq<T>>(&self, attrib: T) -> Result<bool> {
-        let attributes = match self {
-            Self::Ident { attributes, .. } => attributes,
-            Self::Index { attributes, .. } => attributes,
-        };
-        for attribute in attributes.iter() {
-            if let Some(attribute) = T::parse(&attribute.tokens)? {
-                if attribute == attrib {
-                    return Ok(true);
-                }
-            }
-        }
-        Ok(false)
-    }
-
-    /// Returns the first attribute that returns `Some(Self)`. See [`FromAttribute`] for more information.
-    ///
-    /// **note**: Will immediately return `Err(_)` on the first error `T` returns.
-    pub fn get_attribute<T: FromAttribute>(&self) -> Result<Option<T>> {
-        let attributes = match self {
-            Self::Ident { attributes, .. } => attributes,
-            Self::Index { attributes, .. } => attributes,
-        };
-        for attribute in attributes.iter() {
-            if let Some(attribute) = T::parse(&attribute.tokens)? {
-                return Ok(Some(attribute));
-            }
-        }
-        Ok(None)
     }
 }
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -9,7 +9,7 @@ mod generics;
 mod utils;
 mod visibility;
 
-pub use self::attributes::{Attribute, AttributeLocation, FromAttribute};
+pub use self::attributes::{Attribute, AttributeAccess, AttributeLocation, FromAttribute};
 pub use self::body::{EnumBody, EnumVariant, Fields, IdentOrIndex, StructBody, UnnamedField};
 pub(crate) use self::data_type::DataType;
 pub use self::generics::{Generic, GenericConstraints, Generics, Lifetime, SimpleGeneric};


### PR DESCRIPTION
closes #1

- Add `AttributeAccess` extension methods to `Vec<Attribute>`.
- Remove `has_attribute` and `get_attribute` from `IdentOrIndex` and `UnnamedField`. Since their `attributes` field is accessible directly.