### PR TITLE
Fixed an issue where creating a type in a macro input wouldn't parse correctly

### DIFF
--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -135,9 +135,9 @@ impl EnumBody {
         let stream = &mut group.stream().into_iter().peekable();
         while stream.peek().is_some() {
             let attributes = Attribute::try_take(AttributeLocation::Variant, stream)?;
-            let ident = match stream.peek() {
-                Some(TokenTree::Ident(_)) => assume_ident(stream.next()),
-                token => return Error::wrong_token(token, "ident"),
+            let ident = match super::utils::consume_ident(stream) {
+                Some(ident) => ident,
+                None => Error::wrong_token(stream.peek(), "ident")?,
             };
 
             let mut fields = Fields::Unit;

--- a/src/parse/data_type.rs
+++ b/src/parse/data_type.rs
@@ -12,17 +12,16 @@ impl DataType {
     pub(crate) fn take(
         input: &mut Peekable<impl Iterator<Item = TokenTree>>,
     ) -> Result<(Self, Ident)> {
-        if let Some(TokenTree::Ident(_)) = input.peek() {
-            let ident = super::utils::assume_ident(input.next());
+        if let Some(ident) = super::utils::consume_ident(input) {
             let result = match ident.to_string().as_str() {
                 "struct" => DataType::Struct,
                 "enum" => DataType::Enum,
                 _ => return Err(Error::UnknownDataType(ident.span())),
             };
-            return match input.next() {
-                Some(TokenTree::Ident(ident)) => Ok((result, ident)),
-                token => Error::wrong_token(token.as_ref(), "ident"),
-            };
+
+            if let Some(ident) = super::utils::consume_ident(input) {
+                return Ok((result, ident));
+            }
         }
         Error::wrong_token(input.peek(), "ident")
     }

--- a/src/parse/utils.rs
+++ b/src/parse/utils.rs
@@ -24,6 +24,25 @@ pub fn assume_punct(t: Option<TokenTree>, punct: char) -> Punct {
     }
 }
 
+pub fn consume_ident(input: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Option<Ident> {
+    match input.peek() {
+        Some(TokenTree::Ident(_)) => Some(super::utils::assume_ident(input.next())),
+        Some(TokenTree::Group(group)) => {
+            // When calling from a macro_rules!, sometimes an ident is defined as :
+            // Group { delimiter: None, stream: TokenStream [Ident] }
+            let mut stream = group.stream().into_iter();
+            if let Some(TokenTree::Ident(i)) = stream.next() {
+                if stream.next().is_none() {
+                    let _ = input.next();
+                    return Some(i);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 pub fn consume_punct_if(
     input: &mut Peekable<impl Iterator<Item = TokenTree>>,
     punct: char,


### PR DESCRIPTION
In bincode, the following code fails:

```rs
macro_rules! macro_newtype {
    ($name:ident) => {
        #[derive(bincode::Encode, bincode::Decode)]
        #[derive(PartialEq, Eq)]
        pub struct $name(pub usize);
    }
}
macro_newtype!(MacroNewtype);
```

with the error:
```
error: Invalid rust syntax, expected ident, got Some(Group { delimiter: None, stream: TokenStream [Ident { ident: "MacroNewtype", span: #0 bytes(6253..6265) }], span: #109 bytes(6212..6217) })
   --> tests\derive.rs:222:20
    |
222 |         pub struct $name(pub usize);
    |                    ^^^^^
...
225 | macro_newtype!(MacroNewtype);
    | ---------------------------- in this macro invocation
    |
    = note: this error originates in the macro `macro_newtype` (in Nightly builds, run with -Z macro-backtrace for more info)
```

It looks like rust does not actually insert an `TokenTree::Ident` when doing macro expansion, but instead adds a `Group(delimiter: None, TokenStream: [Ident])`. This PR adds a helper function to check for such a case.

Tested with bincode