### PR TITLE
Fixed `bitflags` invocation and added `<F = ()>` parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ readme = "README.md"
 
 [dev-dependencies]
 proc-macro2 = "1.0"
+
+[workspace]
+members = ["test", "test/derive"]

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -351,6 +351,10 @@ impl Fields {
         matches!(self, Self::Unit)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Self::Tuple(fields) => fields.len(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,6 +47,7 @@ use crate::{prelude::*, Error};
 pub fn parse_tagged_attribute(group: &Group, prefix: &str) -> Result<Option<Vec<ParsedAttribute>>> {
     let stream = &mut group.stream().into_iter();
     if let Some(TokenTree::Ident(attribute_ident)) = stream.next() {
+        #[allow(clippy::cmp_owned)] // clippy is wrong
         if attribute_ident.to_string() == prefix {
             if let Some(TokenTree::Group(group)) = stream.next() {
                 let mut result = Vec::new();

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "virtue_test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+virtue_test_derive = { path = "derive" }
+bitflags = "1.3"

--- a/test/derive/Cargo.toml
+++ b/test/derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "virtue_test_derive"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+virtue = { path = "../.." }

--- a/test/derive/src/lib.rs
+++ b/test/derive/src/lib.rs
@@ -1,0 +1,21 @@
+use virtue::prelude::*;
+
+#[proc_macro_derive(RetHi)]
+pub fn derive_ret_hi(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_ret_hi_inner(input).unwrap_or_else(|error| error.into_token_stream())
+}
+
+fn derive_ret_hi_inner(input: proc_macro::TokenStream) -> virtue::Result<proc_macro::TokenStream> {
+    let parse = Parse::new(input)?;
+    let (mut generator, _, _) = parse.into_generator();
+    generator
+        .generate_impl()
+        .generate_fn("hi")
+        .with_self_arg(FnSelfArg::RefSelf)
+        .with_return_type("&'static str")
+        .body(|body| {
+            body.lit_str("hi");
+            Ok(())
+        })?;
+    generator.finish()
+}

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,0 +1,17 @@
+bitflags::bitflags! {
+    #[derive(virtue_test_derive::RetHi)]
+    pub struct Foo: u8 {
+        const A = 1;
+        const B = 1;
+    }
+}
+
+#[derive(virtue_test_derive::RetHi)]
+pub struct DefaultGeneric<T = ()> {
+    pub t: T,
+}
+
+fn main() {
+    assert_eq!("hi", Foo::A.hi());
+    assert_eq!("hi", Foo::B.hi());
+}


### PR DESCRIPTION
- Fixed an issue where virtue wouldn't properly parse a `bitflags` call
- Made virtue parse `<F = ()>` constraints (closes #25) 
- Fixed clippy lints
- Added a test suite