### PR TITLE
Write exported files to `target/generated/<crate_name>`

### DIFF
--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -90,12 +90,12 @@ impl Generator {
     }
 
     /// Export the current stream to a file, making it very easy to debug the output of a derive macro.
-    /// This will try to find rust's `target` file, and write `target/<name>_<file_postfix>.rs`.
+    /// This will try to find rust's `target` directory, and write `target/generated/<crate_name>/<name>_<file_postfix>.rs`.
     ///
     /// Will return `true` if the file is written, `false` otherwise.
     ///
-    /// The outputted file is unformatted. Use `cargo fmt -- target/<file>.rs` to format the file.
-    pub fn export_to_file(&self, file_postfix: &str) -> bool {
+    /// The outputted file is unformatted. Use `cargo fmt -- target/generated/<crate_name>/<file>.rs` to format the file.
+    pub fn export_to_file(&self, crate_name: &str, file_postfix: &str) -> bool {
         use std::io::Write;
 
         if let Ok(var) = std::env::var("CARGO_MANIFEST_DIR") {
@@ -105,6 +105,11 @@ impl Generator {
                     let mut path = path.clone();
                     path.push("target");
                     if path.exists() {
+                        path.push("generated");
+                        path.push(crate_name);
+                        if std::fs::create_dir_all(&path).is_err() {
+                            return false;
+                        }
                         path.push(format!("{}_{}.rs", self.target_name(), file_postfix));
                         if let Ok(mut file) = std::fs::File::create(path) {
                             let _ = file.write_all(self.stream.stream.to_string().as_bytes());


### PR DESCRIPTION
Unblocks https://github.com/bincode-org/bincode/issues/594 and its duplicate https://github.com/bincode-org/bincode/issues/531 .

As before, if this looks good, a crates.io release of `virtue` would be appreciated so I can file a PR for `bincode`.

I elected to use a `generated` subdirectory as this approach might be used by multiple crates, and it seems reasonable to establish an informal naming standard. Note that IDEs will typically pretty-print directories that only contain a single subdirectory:

<img width="253" alt="Screen Shot 2022-10-19 at 9 06 37 AM" src="https://user-images.githubusercontent.com/230691/196603202-e3cbca25-c9aa-4300-8678-608d96393e3d.png">
