### PR TITLE
refactor: remove `I` from `impl_for_with_lifetimes`

### DIFF
--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -71,14 +71,14 @@ impl Generator {
     /// // will output:
     /// // impl<'a, 'b> Foo<'a, 'b> for StructOrEnum { }
     /// ```
-    pub fn impl_for_with_lifetimes<ITER, I, T>(
+    pub fn impl_for_with_lifetimes<ITER, T>(
         &mut self,
         trait_name: T,
         lifetimes: ITER,
     ) -> ImplFor<Self>
     where
-        ITER: IntoIterator<Item = I>,
-        I: Into<String>,
+        ITER: IntoIterator,
+        ITER::Item: Into<String>,
         T: Into<String>,
     {
         ImplFor::new_with_lifetimes(self, trait_name, lifetimes)

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -29,14 +29,14 @@ impl<'a, P: Parent> ImplFor<'a, P> {
         }
     }
 
-    pub(super) fn new_with_lifetimes<ITER, I, T>(
+    pub(super) fn new_with_lifetimes<ITER, T>(
         generator: &'a mut P,
         trait_name: T,
         lifetimes: ITER,
     ) -> Self
     where
-        ITER: IntoIterator<Item = I>,
-        I: Into<String>,
+        ITER: IntoIterator,
+        ITER::Item: Into<String>,
         T: Into<String>,
     {
         Self {


### PR DESCRIPTION
The `I` generic is unnecessary since `Item` is an associated type and cannot be specified independently of `ITER`. I think this is technically a breaking change for anyone explicitly naming all the generic parameters. That said, probably nobody is doing that because these are generic for convenience and ergonomics, not explicit typing. Honestly I would probably just turn both args into `impl Trait` params, but that may just be me.