### PR TITLE
fix: `impl_generics_with_additional_lifetimes`

### DIFF
--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -163,10 +163,7 @@ impl super::Parent for Generator {
 mod test {
     use proc_macro2::Span;
 
-    use crate::{
-        parse::{Generic, Lifetime, SimpleGeneric},
-        token_stream,
-    };
+    use crate::token_stream;
 
     use super::*;
 

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -163,46 +163,66 @@ impl super::Parent for Generator {
 mod test {
     use proc_macro2::Span;
 
-    use crate::{token_stream, parse::{Generic, SimpleGeneric, Lifetime}};
+    use crate::{
+        parse::{Generic, Lifetime, SimpleGeneric},
+        token_stream,
+    };
 
     use super::*;
 
     #[test]
     fn impl_for_with_lifetimes() {
         // No generics
-        let mut generator = Generator::new(
-            Ident::new("StructOrEnum", Span::call_site()),
-            None,
-            None);
+        let mut generator =
+            Generator::new(Ident::new("StructOrEnum", Span::call_site()), None, None);
         let _ = generator.impl_for_with_lifetimes("Foo", ["a", "b"]);
         let output = generator.finish().unwrap();
         assert_eq!(
-            output.into_iter().map(|v| v.to_string()).collect::<String>(),
-            token_stream("impl<'a, 'b> Foo<'a, 'b> for StructOrEnum { }").map(|v| v.to_string()).collect::<String>(),
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream("impl<'a, 'b> Foo<'a, 'b> for StructOrEnum { }")
+                .map(|v| v.to_string())
+                .collect::<String>(),
         );
 
         //with simple generics
         let mut generator = Generator::new(
-           Ident::new("StructOrEnum", Span::call_site()),
-           Generics::try_take(&mut token_stream("<T1, T2>")).unwrap(),
-           None);
+            Ident::new("StructOrEnum", Span::call_site()),
+            Generics::try_take(&mut token_stream("<T1, T2>")).unwrap(),
+            None,
+        );
         let _ = generator.impl_for_with_lifetimes("Foo", ["a", "b"]);
         let output = generator.finish().unwrap();
         assert_eq!(
-           output.into_iter().map(|v| v.to_string()).collect::<String>(),
-           token_stream("impl<'a, 'b, T1, T2> Foo<'a, 'b> for StructOrEnum<T1, T2> { }").map(|v| v.to_string()).collect::<String>()
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream("impl<'a, 'b, T1, T2> Foo<'a, 'b> for StructOrEnum<T1, T2> { }")
+                .map(|v| v.to_string())
+                .collect::<String>()
         );
 
         // with lifetimes
         let mut generator = Generator::new(
             Ident::new("StructOrEnum", Span::call_site()),
             Generics::try_take(&mut token_stream("<'alpha, 'beta>")).unwrap(),
-            None);
+            None,
+        );
         let _ = generator.impl_for_with_lifetimes("Foo", ["a", "b"]);
         let output = generator.finish().unwrap();
         assert_eq!(
-            output.into_iter().map(|v| v.to_string()).collect::<String>(),
-            token_stream("impl<'a, 'b, 'alpha, 'beta> Foo<'a, 'b> for StructOrEnum<'alpha, 'beta> { }").map(|v| v.to_string()).collect::<String>()
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream(
+                "impl<'a, 'b, 'alpha, 'beta> Foo<'a, 'b> for StructOrEnum<'alpha, 'beta> { }"
+            )
+            .map(|v| v.to_string())
+            .collect::<String>()
         );
     }
 }

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -122,18 +122,11 @@ impl Generics {
         for (idx, lt) in lifetime.iter().enumerate() {
             result.punct(if idx == 0 { '<' } else { ',' });
             result.lifetime_str(lt);
+        }
 
-            if self.has_lifetime() {
-                for (idx, lt) in self.iter().filter_map(|lt| lt.as_lifetime()).enumerate() {
-                    result.punct(if idx == 0 { ':' } else { '+' });
-                    result.lifetime(lt.ident.clone());
-                }
-            }
-
-            for generic in self.iter() {
-                result.punct(',');
-                generic.append_to_result_with_constraints(&mut result);
-            }
+        for generic in self.iter() {
+            result.punct(',');
+            generic.append_to_result_with_constraints(&mut result);
         }
 
         result.punct('>');
@@ -218,13 +211,6 @@ impl Generic {
             Self::Lifetime(lt) => lt.ident.clone(),
             Self::Generic(gen) => gen.ident.clone(),
             Self::Const(gen) => gen.ident.clone(),
-        }
-    }
-
-    fn as_lifetime(&self) -> Option<&Lifetime> {
-        match self {
-            Self::Lifetime(lt) => Some(lt),
-            _ => None,
         }
     }
 


### PR DESCRIPTION
I'm not entirely sure why this function was originally trying to bound lifetimes, but regardless, what it currently does is very incorrect as it adds copies of every generic for each lifetime passed in.

I don't think any of that is right, so this fixes that, removes the unused helper `as_lifetime`, and adds a test to ensure the expected behavior occurs.