### PR TITLE
Added a test to validate that trailing commas on `where` conditions are okay

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,6 +104,40 @@ fi",
         }
       ]
     },
+    "test_project": {
+      "name": "Test Project",
+      "runs-on": "ubuntu-latest",
+      "strategy": {
+        "matrix": {
+          "rust": [
+            "stable",
+            # "1.55.0" TODO: Pick latest stable version when we release 0.1
+          ]
+        }
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "${{ matrix.rust }}",
+            "override": true
+          },
+          "name": "Install Rust ${{ matrix.rust }}"
+        },
+        {
+          "run": "cd test && cargo run",
+          "name": "Run the test project",
+          "env": {
+            "RUSTFLAGS": "-D warnings"
+          }
+        }
+      ]
+    },
     "lints": {
       "name": "Lints",
       "runs-on": "ubuntu-latest",

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -617,3 +617,20 @@ fn test_generic_constraints_try_take() {
     let body = StructBody::take(stream).unwrap();
     assert_eq!(body.fields.len(), 0);
 }
+
+#[test]
+fn test_generic_constraints_trailing_comma() {
+    use crate::parse::{
+        Attribute, AttributeLocation, DataType, GenericConstraints, Generics, StructBody,
+        Visibility,
+    };
+    use crate::token_stream;
+    let source = &mut token_stream("pub struct MyStruct<T> where T: Clone, { }");
+
+    let attributes = Attribute::try_take(AttributeLocation::Container, source).unwrap();
+    let visibility = Visibility::try_take(source).unwrap();
+    let (datatype, name) = DataType::take(source).unwrap();
+    let generics = Generics::try_take(source).unwrap().unwrap();
+    let generic_constraints = GenericConstraints::try_take(source).unwrap().unwrap();
+    let body = StructBody::take(source).unwrap();
+}

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -627,10 +627,10 @@ fn test_generic_constraints_trailing_comma() {
     use crate::token_stream;
     let source = &mut token_stream("pub struct MyStruct<T> where T: Clone, { }");
 
-    let attributes = Attribute::try_take(AttributeLocation::Container, source).unwrap();
-    let visibility = Visibility::try_take(source).unwrap();
-    let (datatype, name) = DataType::take(source).unwrap();
-    let generics = Generics::try_take(source).unwrap().unwrap();
-    let generic_constraints = GenericConstraints::try_take(source).unwrap().unwrap();
-    let body = StructBody::take(source).unwrap();
+    Attribute::try_take(AttributeLocation::Container, source).unwrap();
+    Visibility::try_take(source).unwrap();
+    DataType::take(source).unwrap();
+    Generics::try_take(source).unwrap().unwrap();
+    GenericConstraints::try_take(source).unwrap().unwrap();
+    StructBody::take(source).unwrap();
 }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -11,7 +11,16 @@ pub struct DefaultGeneric<T = ()> {
     pub t: T,
 }
 
+#[derive(virtue_test_derive::RetHi, Default)]
+pub struct MyStruct<T>
+where
+    T: Clone,
+{
+    pub b: Vec<T>,
+}
+
 fn main() {
     assert_eq!("hi", Foo::A.hi());
     assert_eq!("hi", Foo::B.hi());
+    assert_eq!("hi", MyStruct::<i32>::default().hi());
 }


### PR DESCRIPTION
Seems to already be fixed in a previous PR somewhere