### PR TITLE
Minor fixes for bincode bump

### DIFF
--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -361,8 +361,10 @@ fn test_generics_try_take() {
 /// a lifetime generic parameter, e.g. `struct Foo<'a> { ... }`
 #[derive(Debug, Clone)]
 pub struct Lifetime {
-    ident: Ident,
-    constraint: Vec<TokenTree>,
+    /// The ident of this lifetime
+    pub ident: Ident,
+    /// Any constraints that this lifetime may have
+    pub constraint: Vec<TokenTree>,
 }
 
 impl Lifetime {
@@ -538,7 +540,11 @@ impl GenericConstraints {
         constraint: impl AsRef<str>,
     ) -> Result<()> {
         let mut builder = StreamBuilder::new();
-        if !self.constraints.is_empty() {
+        let last_constraint_was_comma = self.constraints.last().map_or(
+            false,
+            |l| matches!(l, TokenTree::Punct(c) if c.as_char() == ','),
+        );
+        if !self.constraints.is_empty() && !last_constraint_was_comma {
             builder.punct(',');
         }
         builder.ident(generic.ident.clone());


### PR DESCRIPTION
- Made the fields in `Lifetime` public as bincode needs to access the ident
- Made sure `push_constraint` did not push an extra comma if the last constraint token was already a comma, as this resulted in a double comma