### PR TITLE
feat: Enable multiple calls to `modify_generic_constraints`

### DIFF
--- a/src/generate/impl.rs
+++ b/src/generate/impl.rs
@@ -82,13 +82,13 @@ impl<'a> Impl<'a, Generator> {
         CB: FnOnce(&Generics, &mut GenericConstraints),
     {
         if let Some(generics) = self.parent.generics() {
-            let mut constraints = self
-                .custom_generic_constraints
-                .take()
-                .or_else(|| self.parent.generic_constraints().cloned())
-                .unwrap_or_default();
-            cb(generics, &mut constraints);
-            self.custom_generic_constraints = Some(constraints)
+            let constraints = self.custom_generic_constraints.get_or_insert_with(|| {
+                self.parent
+                    .generic_constraints()
+                    .cloned()
+                    .unwrap_or_default()
+            });
+            cb(generics, constraints);
         }
         self
     }

--- a/src/generate/impl.rs
+++ b/src/generate/impl.rs
@@ -83,9 +83,9 @@ impl<'a> Impl<'a, Generator> {
     {
         if let Some(generics) = self.parent.generics() {
             let mut constraints = self
-                .parent
-                .generic_constraints()
-                .cloned()
+                .custom_generic_constraints
+                .take()
+                .or_else(|| self.parent.generic_constraints().cloned())
                 .unwrap_or_default();
             cb(generics, &mut constraints);
             self.custom_generic_constraints = Some(constraints)

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -148,13 +148,13 @@ impl<'a, P: Parent> ImplFor<'a, P> {
         CB: FnOnce(&Generics, &mut GenericConstraints) -> Result,
     {
         if let Some(generics) = self.generator.generics() {
-            let mut constraints = self
-                .custom_generic_constraints
-                .take()
-                .or_else(|| self.generator.generic_constraints().cloned())
-                .unwrap_or_default();
-            cb(generics, &mut constraints)?;
-            self.custom_generic_constraints = Some(constraints)
+            let constraints = self.custom_generic_constraints.get_or_insert_with(|| {
+                self.generator
+                    .generic_constraints()
+                    .cloned()
+                    .unwrap_or_default()
+            });
+            cb(generics, constraints)?;
         }
         Ok(self)
     }

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -149,9 +149,9 @@ impl<'a, P: Parent> ImplFor<'a, P> {
     {
         if let Some(generics) = self.generator.generics() {
             let mut constraints = self
-                .generator
-                .generic_constraints()
-                .cloned()
+                .custom_generic_constraints
+                .take()
+                .or_else(|| self.generator.generic_constraints().cloned())
                 .unwrap_or_default();
             cb(generics, &mut constraints)?;
             self.custom_generic_constraints = Some(constraints)


### PR DESCRIPTION
Right now, each call to `modify_generic_constraints` overwrites all previous calls. This change makes multiple calls build on each other instead.