### PR TITLE
Impl for other type

### DIFF
--- a/src/generate/gen_struct.rs
+++ b/src/generate/gen_struct.rs
@@ -1,4 +1,4 @@
-use super::{Impl, ImplFor, Parent, StreamBuilder};
+use super::{Impl, ImplFor, Parent, StreamBuilder, StringOrIdent};
 use crate::parse::Visibility;
 use crate::prelude::{Delimiter, Ident, Span};
 
@@ -51,8 +51,8 @@ impl<'a, P: Parent> GenStruct<'a, P> {
     }
 
     /// Add an `impl <name> for <struct>`
-    pub fn impl_for(&mut self, name: impl Into<String>) -> ImplFor<Self> {
-        ImplFor::new(self, name)
+    pub fn impl_for(&mut self, name: impl Into<StringOrIdent>) -> ImplFor<Self> {
+        ImplFor::new(self, name.into(), None)
     }
 
     /// Generate an `impl <name>` implementation. See [`Impl`] for more information.

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -237,13 +237,13 @@ impl<P: Parent> ImplFor<'_, P> {
             builder.append(generics.impl_generics());
         }
         if let Some(t) = &self.trait_name {
-            builder.ident_str(t.to_string());
+            builder.push_parsed(t.to_string()).unwrap();
             if let Some(lifetimes) = &self.lifetimes {
                 append_lifetimes(builder, lifetimes);
             }
             builder.ident_str("for");
         }
-        builder.ident_str(self.type_name.to_string());
+        builder.push_parsed(self.type_name.to_string()).unwrap();
         if let Some(generics) = &self.generator.generics() {
             builder.append(generics.type_generics());
         }

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -1,4 +1,4 @@
-use super::{generate_item::FnParent, FnBuilder, GenConst, Parent, StreamBuilder};
+use super::{generate_item::FnParent, FnBuilder, GenConst, Parent, StreamBuilder, StringOrIdent};
 use crate::{
     parse::{GenericConstraints, Generics},
     prelude::{Delimiter, Result},
@@ -10,7 +10,8 @@ pub struct ImplFor<'a, P: Parent> {
     generator: &'a mut P,
     outer_attr: Vec<StreamBuilder>,
     inner_attr: Vec<StreamBuilder>,
-    trait_name: String,
+    type_name: StringOrIdent,
+    trait_name: Option<StringOrIdent>,
     lifetimes: Option<Vec<String>>,
     consts: Vec<StreamBuilder>,
     custom_generic_constraints: Option<GenericConstraints>,
@@ -19,12 +20,17 @@ pub struct ImplFor<'a, P: Parent> {
 }
 
 impl<'a, P: Parent> ImplFor<'a, P> {
-    pub(super) fn new(generator: &'a mut P, trait_name: impl Into<String>) -> Self {
+    pub(super) fn new(
+        generator: &'a mut P,
+        type_name: StringOrIdent,
+        trait_name: Option<StringOrIdent>,
+    ) -> Self {
         Self {
             generator,
             outer_attr: Vec::new(),
             inner_attr: Vec::new(),
-            trait_name: trait_name.into(),
+            trait_name,
+            type_name,
             lifetimes: None,
             consts: Vec::new(),
             custom_generic_constraints: None,
@@ -33,27 +39,14 @@ impl<'a, P: Parent> ImplFor<'a, P> {
         }
     }
 
-    pub(super) fn new_with_lifetimes<ITER, T>(
-        generator: &'a mut P,
-        trait_name: T,
-        lifetimes: ITER,
-    ) -> Self
+    /// Internal helper function to set lifetimes
+    pub(crate) fn with_lifetimes<ITER>(mut self, lifetimes: ITER) -> Self
     where
         ITER: IntoIterator,
         ITER::Item: Into<String>,
-        T: Into<String>,
     {
-        Self {
-            generator,
-            outer_attr: Vec::new(),
-            inner_attr: Vec::new(),
-            trait_name: trait_name.into(),
-            lifetimes: Some(lifetimes.into_iter().map(Into::into).collect()),
-            consts: Vec::new(),
-            custom_generic_constraints: None,
-            impl_types: Vec::new(),
-            fns: Vec::new(),
-        }
+        self.lifetimes = Some(lifetimes.into_iter().map(Into::into).collect());
+        self
     }
 
     /// Add a outer attribute to the trait implementation
@@ -243,12 +236,14 @@ impl<P: Parent> ImplFor<'_, P> {
         } else if let Some(generics) = self.generator.generics() {
             builder.append(generics.impl_generics());
         }
-        builder.push_parsed(&self.trait_name).unwrap();
-        if let Some(lifetimes) = &self.lifetimes {
-            append_lifetimes(builder, lifetimes);
+        if let Some(t) = &self.trait_name {
+            builder.ident_str(t.to_string());
+            if let Some(lifetimes) = &self.lifetimes {
+                append_lifetimes(builder, lifetimes);
+            }
+            builder.ident_str("for");
         }
-        builder.ident_str("for");
-        builder.ident_str(self.generator.name().to_string());
+        builder.ident_str(self.type_name.to_string());
         if let Some(generics) = &self.generator.generics() {
             builder.append(generics.type_generics());
         }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     parse::{GenericConstraints, Generics},
     prelude::Ident,
 };
+use std::fmt;
 
 pub use self::gen_struct::GenStruct;
 pub use self::generate_item::{FnBuilder, FnSelfArg, GenConst};
@@ -40,4 +41,36 @@ pub trait Parent {
     fn name(&self) -> &Ident;
     fn generics(&self) -> Option<&Generics>;
     fn generic_constraints(&self) -> Option<&GenericConstraints>;
+}
+
+/// Helper enum to differentiate between a [`Ident`] or a [`String`]
+#[allow(missing_docs)]
+pub enum StringOrIdent {
+    String(String),
+    Ident(Ident),
+}
+
+impl fmt::Display for StringOrIdent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(s) => s.fmt(f),
+            Self::Ident(i) => i.fmt(f),
+        }
+    }
+}
+
+impl From<String> for StringOrIdent {
+    fn from(s: String) -> Self {
+        Self::String(s)
+    }
+}
+impl From<Ident> for StringOrIdent {
+    fn from(i: Ident) -> Self {
+        Self::Ident(i)
+    }
+}
+impl<'a> From<&'a str> for StringOrIdent {
+    fn from(s: &'a str) -> Self {
+        Self::String(s.to_owned())
+    }
 }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -43,10 +43,12 @@ pub trait Parent {
     fn generic_constraints(&self) -> Option<&GenericConstraints>;
 }
 
-/// Helper enum to differentiate between a [`Ident`] or a [`String`]
+/// Helper enum to differentiate between a [`Ident`] or a [`String`].
 #[allow(missing_docs)]
 pub enum StringOrIdent {
     String(String),
+    // Note that when this is a `string` this could be much more than a single ident.
+    // Therefor you should never use [`StreamBuilder`]`.ident_str(StringOrIdent.to_string())`, but instead use `.push_parsed(StringOrIdent.to_string())?`.
     Ident(Ident),
 }
 


### PR DESCRIPTION
Added the ability to generate an `ImplFor` struct for another type, different than what the generator is based on.
```rs
generator.impl_for_other_type("Foo");

// will output:
// impl Foo { }
```

```rs
generator.impl_trait_for_other_type("Foo", "Bar");

// will output:
// impl Foo for Bar { }
```