### PR TITLE
Fix wrong delimiter around attributes

### DIFF
--- a/src/generate/generate_item.rs
+++ b/src/generate/generate_item.rs
@@ -73,7 +73,7 @@ impl<'a> GenConst<'a> {
             builder
                 .punct('#')
                 .punct('!')
-                .group(Delimiter::Brace, |builder| {
+                .group(Delimiter::Bracket, |builder| {
                     builder.push_parsed(attr)?;
                     Ok(())
                 })?;
@@ -350,7 +350,7 @@ impl<'a, P: FnParent> FnBuilder<'a, P> {
 
         // attrs
         for attr in attrs {
-            builder.punct('#').group(Delimiter::Brace, |builder| {
+            builder.punct('#').group(Delimiter::Bracket, |builder| {
                 builder.push_parsed(attr)?;
                 Ok(())
             })?;

--- a/src/generate/impl.rs
+++ b/src/generate/impl.rs
@@ -45,7 +45,7 @@ impl<'a, P: Parent> Impl<'a, P> {
     /// Add a outer attribute to the trait implementation
     pub fn impl_outer_attr(&mut self, attr: impl AsRef<str>) -> Result {
         let mut builder = StreamBuilder::new();
-        builder.punct('#').group(Delimiter::Brace, |builder| {
+        builder.punct('#').group(Delimiter::Bracket, |builder| {
             builder.push_parsed(attr)?;
             Ok(())
         })?;

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -80,7 +80,7 @@ impl<'a, P: Parent> ImplFor<'a, P> {
     /// Add a outer attribute to the trait implementation
     pub fn impl_outer_attr(&mut self, attr: impl AsRef<str>) -> Result {
         let mut builder = StreamBuilder::new();
-        builder.punct('#').group(Delimiter::Brace, |builder| {
+        builder.punct('#').group(Delimiter::Bracket, |builder| {
             builder.push_parsed(attr)?;
             Ok(())
         })?;

--- a/test/derive/src/lib.rs
+++ b/test/derive/src/lib.rs
@@ -11,6 +11,7 @@ fn derive_ret_hi_inner(input: TokenStream) -> Result<TokenStream> {
     generator
         .generate_impl()
         .generate_fn("hi")
+        .with_attr("inline(never)")
         .with_self_arg(FnSelfArg::RefSelf)
         .with_return_type("&'static str")
         .body(|body| {


### PR DESCRIPTION
Currently if you try to apply attributes to a function you will get an error parsing the token stream as it adds curly braces instead of square ones,
Fixed by instead using square brackets everywhere there's a attribute encoding