### PR TITLE
 pub incorrectly consuming a field type

### DIFF
--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -127,6 +127,24 @@ fn test_struct_body_take() {
     }
 }
 
+#[test]
+fn issue_77() {
+    // https://github.com/bincode-org/virtue/issues/77
+    use crate::token_stream;
+
+    let stream = &mut token_stream("struct Test(pub [u8; 32])");
+    let (data_type, ident) = super::DataType::take(stream).unwrap();
+    assert_eq!(data_type, super::DataType::Struct);
+    assert_eq!(ident, "Test");
+    let body = StructBody::take(stream).unwrap();
+    let fields = body.fields.unwrap();
+    let Fields::Tuple(t) = fields else {
+        panic!("Fields is not a tuple")
+    };
+    assert_eq!(t.len(), 1);
+    assert_eq!(t[0].r#type[0].to_string(), "[u8 ; 32 ]");
+}
+
 /// The body of an enum
 #[derive(Debug)]
 pub struct EnumBody {

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -143,6 +143,18 @@ fn issue_77() {
     };
     assert_eq!(t.len(), 1);
     assert_eq!(t[0].r#type[0].to_string(), "[u8 ; 32]");
+
+    let stream = &mut token_stream("struct Foo(pub (u8, ))");
+    let (data_type, ident) = super::DataType::take(stream).unwrap();
+    assert_eq!(data_type, super::DataType::Struct);
+    assert_eq!(ident, "Foo");
+    let body = StructBody::take(stream).unwrap();
+    let fields = body.fields.unwrap();
+    let Fields::Tuple(t) = fields else {
+        panic!("Fields is not a tuple")
+    };
+    assert_eq!(t.len(), 1);
+    assert_eq!(t[0].r#type[0].to_string(), "(u8 ,)");
 }
 
 /// The body of an enum

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -142,7 +142,7 @@ fn issue_77() {
         panic!("Fields is not a tuple")
     };
     assert_eq!(t.len(), 1);
-    assert_eq!(t[0].r#type[0].to_string(), "[u8 ; 32 ]");
+    assert_eq!(t[0].r#type[0].to_string(), "[u8 ; 32]");
 }
 
 /// The body of an enum

--- a/src/parse/visibility.rs
+++ b/src/parse/visibility.rs
@@ -1,5 +1,5 @@
 use super::utils::*;
-use crate::prelude::TokenTree;
+use crate::prelude::{Delimiter, TokenTree};
 use crate::Result;
 use std::iter::Peekable;
 
@@ -21,9 +21,11 @@ impl Visibility {
                 assume_ident(input.next());
 
                 // check if the next token is `pub(...)`
-                if let Some(TokenTree::Group(_)) = input.peek() {
-                    // we just consume the visibility, we're not actually using it for generation
-                    assume_group(input.next());
+                if let Some(TokenTree::Group(g)) = input.peek() {
+                    if g.delimiter() == Delimiter::Parenthesis {
+                        // we just consume the visibility, we're not actually using it for generation
+                        assume_group(input.next());
+                    }
                 }
 
                 Ok(Visibility::Pub)

--- a/src/parse/visibility.rs
+++ b/src/parse/visibility.rs
@@ -23,8 +23,17 @@ impl Visibility {
                 // check if the next token is `pub(...)`
                 if let Some(TokenTree::Group(g)) = input.peek() {
                     if g.delimiter() == Delimiter::Parenthesis {
-                        // we just consume the visibility, we're not actually using it for generation
-                        assume_group(input.next());
+                        // check if this is one of:
+                        // - pub ( crate )
+                        // - pub ( self )
+                        // - pub ( super )
+                        // - pub ( in ... )
+                        if let Some(TokenTree::Ident(i)) = g.stream().into_iter().next() {
+                            if matches!(i.to_string().as_str(), "crate" | "self" | "super" | "in") {
+                                // it is, ignore this token
+                                assume_group(input.next());
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #77 

`Visibility::try_take` has a case where given `pub(self)` it ignores the `(self)`. It incorrectly assumed `pub [u8; 2]` was similar. This PR fixes it so it only ignores `(...)` and not `[...]`