### PR TITLE
Allow adding generics to `impl` and trait name

### DIFF
--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -309,5 +309,63 @@ mod test {
             .collect::<String>()
         );
     }
-    // TODO test with_impl_generics
+
+    #[test]
+    fn impl_for_with_trait_generics() {
+        let mut generator = Generator::new(
+            Ident::new("StructOrEnum", Span::call_site()),
+            Generics::try_take(&mut token_stream("<'a>")).unwrap(),
+            None,
+        );
+        let _ = generator.impl_for("Foo").with_trait_generics(["&'a str"]);
+        let output = generator.finish().unwrap();
+        assert_eq!(
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream("impl<'a> Foo<&'a str> for StructOrEnum<'a> { }")
+                .map(|v| v.to_string())
+                .collect::<String>(),
+        );
+    }
+
+    #[test]
+    fn impl_for_with_impl_generics() {
+        //with simple generics
+        let mut generator = Generator::new(
+            Ident::new("StructOrEnum", Span::call_site()),
+            Generics::try_take(&mut token_stream("<T1, T2>")).unwrap(),
+            None,
+        );
+        let _ = generator.impl_for("Foo").with_impl_generics(["Bar"]);
+
+        let output = generator.finish().unwrap();
+        assert_eq!(
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream("impl<T1, T2, Bar> Foo for StructOrEnum<T1, T2> { }")
+                .map(|v| v.to_string())
+                .collect::<String>()
+        );
+        // with lifetimes
+        let mut generator = Generator::new(
+            Ident::new("StructOrEnum", Span::call_site()),
+            Generics::try_take(&mut token_stream("<'alpha, 'beta>")).unwrap(),
+            None,
+        );
+        let _ = generator.impl_for("Foo").with_impl_generics(["Bar"]);
+        let output = generator.finish().unwrap();
+        assert_eq!(
+            output
+                .into_iter()
+                .map(|v| v.to_string())
+                .collect::<String>(),
+            token_stream("impl<'alpha, 'beta, Bar> Foo for StructOrEnum<'alpha, 'beta> { }")
+                .map(|v| v.to_string())
+                .collect::<String>()
+        );
+    }
 }

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -309,4 +309,5 @@ mod test {
             .collect::<String>()
         );
     }
+    // TODO test with_impl_generics
 }

--- a/src/generate/impl_for.rs
+++ b/src/generate/impl_for.rs
@@ -362,7 +362,7 @@ fn append_lifetimes_and_generics(
         if idx > 0 || !lifetimes.is_empty() {
             builder.punct(',');
         }
-        builder.ident_str(gen);
+        builder.push_parsed(gen).unwrap();
     }
 
     builder.punct('>');

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -364,6 +364,7 @@ pub struct EnumVariant {
     /// - `Baz = 5`
     /// - `Baz(i32) = 5`
     /// - `Baz { a: i32} = 5`
+    /// 
     /// In either case this value will be `Some(Literal::i32(5))`
     pub value: Option<Literal>,
     /// The attributes of this variant

--- a/src/parse/body.rs
+++ b/src/parse/body.rs
@@ -364,7 +364,7 @@ pub struct EnumVariant {
     /// - `Baz = 5`
     /// - `Baz(i32) = 5`
     /// - `Baz { a: i32} = 5`
-    /// 
+    ///
     /// In either case this value will be `Some(Literal::i32(5))`
     pub value: Option<Literal>,
     /// The attributes of this variant

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -114,12 +114,13 @@ impl Generics {
         result
     }
 
-    pub(crate) fn impl_generics_with_additional_lifetimes(
+    pub(crate) fn impl_generics_with_additional(
         &self,
-        lifetime: &[String],
+        lifetimes: &[String],
+        types: &[String],
     ) -> StreamBuilder {
         let mut result = StreamBuilder::new();
-        for (idx, lt) in lifetime.iter().enumerate() {
+        for (idx, lt) in lifetimes.iter().enumerate() {
             result.punct(if idx == 0 { '<' } else { ',' });
             result.lifetime_str(lt);
         }
@@ -127,6 +128,10 @@ impl Generics {
         for generic in self.iter() {
             result.punct(',');
             generic.append_to_result_with_constraints(&mut result);
+        }
+        for ty in types {
+            result.punct(',');
+            result.ident_str(ty);
         }
 
         result.punct('>');

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -120,17 +120,31 @@ impl Generics {
         types: &[String],
     ) -> StreamBuilder {
         let mut result = StreamBuilder::new();
-        for (idx, lt) in lifetimes.iter().enumerate() {
-            result.punct(if idx == 0 { '<' } else { ',' });
+        result.punct('<');
+        let mut is_first = true;
+        for lt in lifetimes.iter() {
+            if !is_first {
+                result.punct(',');
+            } else {
+                is_first = false;
+            }
             result.lifetime_str(lt);
         }
 
         for generic in self.iter() {
-            result.punct(',');
+            if !is_first {
+                result.punct(',');
+            } else {
+                is_first = false;
+            }
             generic.append_to_result_with_constraints(&mut result);
         }
         for ty in types {
-            result.punct(',');
+            if !is_first {
+                result.punct(',');
+            } else {
+                is_first = false;
+            }
             result.ident_str(ty);
         }
 


### PR DESCRIPTION
Prerequisites of https://github.com/bincode-org/bincode/pull/710.

This PR allows
- adding generics after the trait name: `impl<'a> Foo<&'a str> for StructOrEnum<'a>`
- adding generics after the `impl` keyword: `impl<T1, T2, Bar> Foo for StructOrEnum<T1, T2>`
