### PR TITLE
Switch public interface to always use proc-macro2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@
                 "name": "Install Rust ${{ matrix.rust }}",
               },
               {
-                "run": "cargo test --all --features proc-macro2",
+                "run": "cargo test --all --all-features",
                 "name": "Run `cargo test`",
                 "env": { "RUSTFLAGS": "-D warnings" },
               },

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,11 +156,11 @@
               },
               {
                 "name": "Upload to codecov.io",
-                "uses": "codecov/codecov-action@v3",
+                "uses": "codecov/codecov-action@v5",
               },
               {
                 "name": "Archive code coverage results",
-                "uses": "actions/upload-artifact@v3",
+                "uses": "actions/upload-artifact@v4",
                 "with":
                   { "name": "code-coverage-report", "path": "cobertura.xml" },
               },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtue"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 description = "A sinless derive macro helper"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,17 @@ documentation = "https://docs.rs/virtue"
 repository = "https://github.com/bincode-org/virtue"
 readme = "README.md"
 
+[dependencies]
+proc-macro2 = { version = "1.0", default-features = false }
+
 [dev-dependencies]
 proc-macro2 = "1.0"
 
-[dependencies]
-proc-macro2 = { version = "1.0", optional = true }
+[features]
+default = ["proc-macro"]
+# Disabling the proc-macro feature removes the dynamic library dependency on
+# libproc_macro in the rustc compiler.
+proc-macro = ["proc-macro2/proc-macro"]
 
 [workspace]
 members = ["test", "test/derive"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,10 +113,12 @@ impl Error {
 // helper functions for the unit tests
 #[cfg(test)]
 impl Error {
+    /// Check if this error is `[Self::UnknownDataType]`
     pub fn is_unknown_data_type(&self) -> bool {
         matches!(self, Error::UnknownDataType(_))
     }
 
+    /// Check if this error is `[Self::ExpectedIdent]`
     pub fn is_invalid_rust_syntax(&self) -> bool {
         matches!(self, Error::InvalidRustSyntax { .. })
     }

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -194,7 +194,6 @@ impl Generator {
     }
 }
 
-#[cfg(feature = "proc-macro2")]
 impl Generator {
     /// Create a new generator with the name `name`. This is useful for testing purposes in combination with the `assert_eq` function.
     pub fn with_name(name: &str) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@
 //! ```
 #![warn(missing_docs)]
 
+#[cfg(feature = "proc-macro")]
+extern crate proc_macro;
+
 mod error;
 
 pub mod generate;
@@ -87,14 +90,7 @@ pub mod prelude {
         AttributeAccess, Body, EnumVariant, Fields, FromAttribute, Parse, UnnamedField,
     };
     pub use crate::{Error, Result};
-
-    #[cfg(any(test, feature = "proc-macro2"))]
     pub use proc_macro2::*;
-
-    #[cfg(not(any(test, feature = "proc-macro2")))]
-    extern crate proc_macro;
-    #[cfg(not(any(test, feature = "proc-macro2")))]
-    pub use proc_macro::*;
 }
 
 #[cfg(test)]

--- a/src/parse/generics.rs
+++ b/src/parse/generics.rs
@@ -563,10 +563,10 @@ impl GenericConstraints {
         constraint: impl AsRef<str>,
     ) -> Result<()> {
         let mut builder = StreamBuilder::new();
-        let last_constraint_was_comma = self.constraints.last().map_or(
-            false,
-            |l| matches!(l, TokenTree::Punct(c) if c.as_char() == ','),
-        );
+        let last_constraint_was_comma = self
+            .constraints
+            .last()
+            .is_some_and(|l| matches!(l, TokenTree::Punct(c) if c.as_char() == ','));
         if !self.constraints.is_empty() && !last_constraint_was_comma {
             builder.punct(',');
         }

--- a/src/parse/utils.rs
+++ b/src/parse/utils.rs
@@ -58,14 +58,8 @@ pub fn consume_punct_if(
     None
 }
 
-#[cfg(any(test, feature = "proc-macro2"))]
 pub fn ident_eq(ident: &Ident, text: &str) -> bool {
     ident == text
-}
-
-#[cfg(not(any(test, feature = "proc-macro2")))]
-pub fn ident_eq(ident: &Ident, text: &str) -> bool {
-    ident.to_string() == text
 }
 
 fn check_if_arrow(tokens: &[TokenTree], punct: &Punct) -> bool {

--- a/test/derive/src/lib.rs
+++ b/test/derive/src/lib.rs
@@ -1,8 +1,10 @@
 use virtue::prelude::*;
 
 #[proc_macro_derive(RetHi)]
-pub fn derive_ret_hi(input: TokenStream) -> TokenStream {
-    derive_ret_hi_inner(input).unwrap_or_else(|error| error.into_token_stream())
+pub fn derive_ret_hi(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_ret_hi_inner(input.into())
+        .unwrap_or_else(|error| error.into_token_stream())
+        .into()
 }
 
 fn derive_ret_hi_inner(input: TokenStream) -> Result<TokenStream> {


### PR DESCRIPTION
This aligns more with how [`quote`](https://docs.rs/quote/latest/quote/macro.quote.html) works:

> Performs variable interpolation against the input and produces it as [proc_macro2::TokenStream](https://docs.rs/proc-macro2/1.0.95/x86_64-unknown-linux-gnu/proc_macro2/struct.TokenStream.html).
> 
> Note: for returning tokens to the compiler in a procedural macro, use .into() on the result to convert to [proc_macro::TokenStream](https://doc.rust-lang.org/nightly/proc_macro/struct.TokenStream.html).

Also: https://github.com/dtolnay/quote/blob/62fd385a800f7398ab416c00100664479261a86e/Cargo.toml#L15-L26

In practice, I got to it because I encountered the following problem:
I have a workspace similiar to bincode/serde, where I have a workspace with crate `A` and a `derive` crate,
the `derive` uses `virtue` and contains a bunch of test vectors that are done by using `proc_macro2` in the proc-macro unit tests.
crate `A` also depends on `bincode`(in tests/benchmarks) and uses its derive proc-macro.
This means that when I run `cargo t --all`, then the tests of crate `A` will use `bincode-derive->virtue` with the `proc-macro2` feature enabled (as they are needed in the `derive` crate dev-depdencies).

This causes `bincode-derive` to fail with this error:
```rust
error[E0308]: mismatched types
   --> /Users/elichai2/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bincode_derive-2.0.1/src/lib.rs:10:25
    |
10  |     derive_encode_inner(input).unwrap_or_else(|e| e.into_token_stream())
    |     ------------------- ^^^^^ expected `virtue::prelude::TokenStream`, found `proc_macro::TokenStream`
    |     |
    |     arguments to this function are incorrect
```

The intrinsic problem here is that the current `proc-macro2` feature is not strictly *additive*,
I also thought about removing `TokenStream` from the prelude of this crate, but decided to leave it as `proc_macro2::TokenStream` but I'm more than willing to just remove it and force users to explicitly import from the "right" place