### PR TITLE
Fix parsing of defaults in generics

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 bitflags::bitflags! {
     #[derive(virtue_test_derive::RetHi)]
     pub struct Foo: u8 {
@@ -7,7 +9,7 @@ bitflags::bitflags! {
 }
 
 #[derive(virtue_test_derive::RetHi)]
-pub struct DefaultGeneric<T = ()> {
+pub struct DefaultGeneric<T: Debug = ()> {
     pub t: T,
 }
 


### PR DESCRIPTION
I ran into this while using the bincode derive macros.

There were two bugs:
- Defaults used in combination with constraints would get parsed as part of the constraints because we didn't stop consuming tokens when encountering `=`.
- Defaults used in const generics weren't handled at all.

API changes:
- This add a new field to the `ConstGeneric` struct.